### PR TITLE
SPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .tests
 node_modules
 build/
+/.build/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterQuery",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [
+        .library(name: "TreeSitterQuery", targets: ["TreeSitterQuery"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterQuery",
+                path: ".",
+                exclude: [
+                    "binding.gyp",
+                    "bindings",
+                    "Cargo.toml",
+                    "corpus",
+                    "grammar.js",
+                    "LICENSE",
+                    "Makefile",
+                    "package.json",
+                    "package-lock.json",
+                    "README.md",
+                    "scripts",
+                    "src/grammar.json",
+                    "src/node-types.json",
+                ],
+                sources: [
+                    "src/parser.c",
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")])
+    ]
+)

--- a/bindings/swift/TreeSitterQuery/query.h
+++ b/bindings/swift/TreeSitterQuery/query.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_QUERY_H_
+#define TREE_SITTER_QUERY_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_query();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_QUERY_H_


### PR DESCRIPTION
This adds Swift bindings and Swift Package Manager (SPM) support. I maintain the tree-sitter Swift binding here https://github.com/chimeHQ/SwiftTreeSitter

Here are some examples of other PRs:

tree-sitter/tree-sitter-go#79
tree-sitter/tree-sitter-c#105
tree-sitter/tree-sitter-haskell#91

These are manually created. They should not ever impact the parser. Changes that require the use of a cpp scanner, which some parsers need, would require an update. The exclude patterns are pretty safe to get out of sync. They can, in some circumstances, generate warnings for Swift users. But, it's really minor.

Oh, and thanks for making this, it's really cool.