### PR TITLE
chore(build): fill necessary metadata for `cargo publish`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-query"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
 name = "tree-sitter-query"
 description = "query grammar for the tree-sitter parsing library"
-version = "0.0.1"
+version = "0.1.0"
 keywords = ["incremental", "parsing", "query"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/nvim-treesitter/tree-sitter-query"
+homepage = "https://github.com/nvim-treesitter/tree-sitter-query"
 edition = "2021"
+readme = "README.md"
+authors = ["nvim-treesitter"]
+license = "Apache-2.0"
 
 build = "bindings/rust/build.rs"
 include = [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-query",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "",
   "main": "bindings/node",
   "scripts": {


### PR DESCRIPTION
After this PR I can run `cargo publish`. Would use my personal crates.io account. I don't expect that this parser will require many updates in future (as it didn't need to change in the past)

Fixes #22