### PR TITLE
chore: add `target` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 build/
 /.build/
+target


### PR DESCRIPTION
Npm will ignore global .gitignore. To not include cargo build artifacts into NPM packages we should add `target` to .gitignore which also servers as .npmignore